### PR TITLE
feat(ox_lib/modules): Add ignorePlayerId server-side

### DIFF
--- a/pages/ox_lib/Modules/GetClosestPlayer/Client.mdx
+++ b/pages/ox_lib/Modules/GetClosestPlayer/Client.mdx
@@ -1,0 +1,24 @@
+# Client
+
+## lib.getClosestPlayer
+
+Get the player id, ped handle, and coords of the closest player to a set of coordinates.
+
+```lua
+lib.getClosestPlayer(coords, maxDistance, includePlayer)
+```
+
+- coords: `vector3`
+  - The coords to check from.
+- maxDistance?: `number`
+  - The max distance to check.
+  - Default: `2.0`
+- includePlayer?: `boolean`
+  - Whether or not to include the current player.
+  - Default: `false`
+
+Return:
+
+- playerId?: `number`
+- playerPed?: `number`
+- playerCoords?: `vector3`

--- a/pages/ox_lib/Modules/GetClosestPlayer/Server.mdx
+++ b/pages/ox_lib/Modules/GetClosestPlayer/Server.mdx
@@ -1,11 +1,11 @@
-# Shared
+# Server
 
 ## lib.getClosestPlayer
 
 Get the player id, ped handle, and coords of the closest player to a set of coordinates.
 
 ```lua
-lib.getClosestPlayer(coords, maxDistance, includePlayer)
+lib.getClosestPlayer(coords, maxDistance, ignorePlayerId)
 ```
 
 - coords: `vector3`
@@ -13,8 +13,8 @@ lib.getClosestPlayer(coords, maxDistance, includePlayer)
 - maxDistance?: `number`
   - The max distance to check.
   - Default: `2.0`
-- includePlayer?: `boolean`
-  - Whether or not to include the current player. Ignored on the server.
+- ignorePlayerId?: `number`|`false`
+  - A player ID to ignore when checking. Set to `false` to include all players.
   - Default: `false`
 
 Return:


### PR DESCRIPTION
Adds docs for [`ox_lib` PR #11](https://github.com/CommunityOx/ox_lib/pull/11).

Also splits the Shared docs into separate Client and Server sections to match the structure used in `ox_lib`.