### PR TITLE
feat(ox_core): add global states documentation

### DIFF
--- a/pages/ox_core/States.mdx
+++ b/pages/ox_core/States.mdx
@@ -1,0 +1,77 @@
+import { Callout, Tabs } from 'nextra/components';
+
+# Global State Bags
+
+<Callout type="warning">
+These global state bags are automatically assigned by ox_core and therefore should not be edited.
+</Callout>
+
+## groups
+Contains an array of the names of all registered groups.
+
+**Returns**
+- `string[]`
+
+## group.\<name\>
+Contains information about the specified group.
+
+**Returns**
+- data: `object`
+  - name: `string`
+  - label: `string`
+  - grades: `string[]`
+  - type: `string`
+  - hasAccount: `boolean`
+  - accountRoles: `string[]`
+  - principal: `string`
+
+## \<name\>:count
+Contains the number of players that have the specified group.
+
+**Returns**
+- `number`
+
+## \<name\>:activeCount
+Contains the number of players that have the specified group set as active.
+
+**Returns**
+- `number`
+
+## status.\<name\>
+Contains information about the specified status.
+
+**Returns**
+- data: `object`
+  - name: `string`
+  - default: `number`
+  - onTick: `number`
+
+## license.\<name\>
+Contains information about the specified license.
+
+**Returns**
+- data: `object`
+  - label: `string`
+
+## accountRoles
+Contains an array of the names of all registered account roles.
+
+**Returns**
+- `string[]`
+
+## accountRole.\<name\>
+Contains information about the specified account role.
+
+**Returns**
+- data: `object`
+  - deposit: `0` | `1`
+  - withdraw: `0` | `1`
+  - addUser: `0` | `1`
+  - removeUser: `0` | `1`
+  - manageUser: `0` | `1`
+  - transferOwnership: `0` | `1`
+  - viewHistory: `0` | `1`
+  - manageAccount: `0` | `1`
+  - closeAccount: `0` | `1`
+  - sendInvoice: `0` | `1`
+  - payInvoice: `0` | `1`


### PR DESCRIPTION
This PR aims to add a page that documents all global state bags that are assigned by ox_core. These contain information about:
- Groups
- Licenses
- Statuses
- Account Roles

Please let me know if you think any changes should be made to this page :)