### PR TITLE
Added RemoveInventory export for ox_inventory

### DIFF
--- a/pages/ox_inventory/Functions/Server.mdx
+++ b/pages/ox_inventory/Functions/Server.mdx
@@ -676,6 +676,16 @@ exports.ox_inventory:ClearInventory(inv, keep)
 - inv: `table` or `string` or `number`
 - keep?: `string` or `string[]`
 
+## RemoveInventory
+
+Removes an inventory from runtime and save it if it's not a temporary stash, dumpster or drop.
+
+```lua
+exports.ox_inventory:RemoveInventory(inventoryId)
+```
+
+- inventoryId: `string`
+
 ## Search
 
 Searches an inventory for a specified item.

--- a/pages/ox_inventory/Functions/Server.mdx
+++ b/pages/ox_inventory/Functions/Server.mdx
@@ -681,7 +681,7 @@ exports.ox_inventory:ClearInventory(inv, keep)
 Removes an inventory from runtime and save it if it's not a temporary stash, dumpster or drop.
 
 ```lua
-exports.ox_inventory:RemoveInventory(inventoryId)
+exports.ox_inventory:RemoveInventory(inv)
 ```
 
 - inv: `table` or `string` or `number`

--- a/pages/ox_inventory/Functions/Server.mdx
+++ b/pages/ox_inventory/Functions/Server.mdx
@@ -684,7 +684,7 @@ Removes an inventory from runtime and save it if it's not a temporary stash, dum
 exports.ox_inventory:RemoveInventory(inventoryId)
 ```
 
-- inventoryId: `string`
+- inv: `table` or `string` or `number`
 
 ## Search
 


### PR DESCRIPTION
Added missing documentation for the `RemoveInventory` export available in ox_inventory.
At this time it's set below ClearInventory, being related to the type action (destructive).

Ox_inventory code of RemoveInventory:
> https://github.com/CommunityOx/ox_inventory/blob/86f59f8099ae743b65d6a6aae503a89d30880f99/modules/inventory/server.lua#L613-L643
