### PR TITLE
chore(logger): update fivemanage requirements

### DIFF
--- a/pages/ox_lib/Modules/Logger/Server.mdx
+++ b/pages/ox_lib/Modules/Logger/Server.mdx
@@ -93,8 +93,10 @@ It is designed to be very cost effective and easy to operate.
 <Steps>
     ### Create an account
     Sign up at [Fivemanage](https://fivemanage.com/?ref=overextended).
-    ### Make sure you have the `Hobby` or `Pro` plan. 
-    You'll get a 14-days free trial if you do not already have an subscription, you can find more information [here](https://fivemanage.com/profile/billing?ref=overextended) and on the [pricing](https://fivemanage.com/pricing?ref=overextended) page.
+    #### Upgrading to `Hobby` or `Pro` tier (optional)
+    Logging is included in the free tier, but with limited storage and retention.
+    
+    If you decide to upgrade, you'll get a 14-day free trial if you do not already have a subscription. You can find more information [here](https://fivemanage.com/profile/billing?ref=overextended) and on the [pricing](https://fivemanage.com/pricing?ref=overextended) page.
     ### Create a new token
     You'll need to create a new token with the type `Logs`.
     ### Config


### PR DESCRIPTION
As recently announced by Fivemanage, logging is being made available to the free tier, and the docs should be updated as such.
According to Fivemanage, these changes to logging will take effect on 20/06/2025. 
https://fivemanage.com/blog/free-logging