### PR TITLE
chore(ox_inventory): Add missing parameter 'strict' from RemoveItem and add weapon components metadata example

### DIFF
--- a/pages/ox_inventory/Functions/Server.mdx
+++ b/pages/ox_inventory/Functions/Server.mdx
@@ -178,7 +178,7 @@ print(json.encode(response, {indent=true}))
 Removes the specified item from the specified inventory.
 
 ```lua
-exports.ox_inventory:RemoveItem(inv, item, count, metadata, slot, ignoreTotal)
+exports.ox_inventory:RemoveItem(inv, item, count, metadata, slot, ignoreTotal, strict)
 ```
 
 - inv: `table` or `string` or `number`
@@ -196,6 +196,8 @@ exports.ox_inventory:RemoveItem(inv, item, count, metadata, slot, ignoreTotal)
   - A specific slot to remove the item from. If the slot is invalid, the first available slot will be used instead.
 - ignoreTotal?: `boolean`
   - Removes as many items as possible up to count.
+- strict?: `boolean`
+  - If true (default), requires an exact match on item + metadata; if false, allows looser/partial matches.
 
 Returns success: `boolean`, response: `string?`.
 

--- a/pages/ox_inventory/Guides/metadata.mdx
+++ b/pages/ox_inventory/Guides/metadata.mdx
@@ -116,3 +116,21 @@ exports.ox_inventory:displayMetadata({
     defense = 'DEF'
 })
 ```
+
+## Weapon components metadata
+
+You can also create items with already attached weapon components by using the `components` metadata property.
+Weapon components are defined in [data/weapons.lua](https://github.com/CommunityOx/ox_inventory/blob/4d178a50a225661eeadcefc5b531c52e10522191/data/weapons.lua#L721)
+You can also set ammo count with the `ammo` metadata property.
+
+```lua
+local metadataExample = {
+    ammo = 30,
+    components = {
+        'at_flashlight',
+        'at_suppressor_heavy'
+    }
+}
+
+exports.ox_inventory:AddItem(inv, item, count, metadataExample, slot, cb)
+```


### PR DESCRIPTION
As the title says: Add missing parameter 'strict' from RemoveItem and add weapon components metadata example