### PR TITLE
feat(ox_core): add param previousGroupName to setActiveGroup event

### DIFF
--- a/pages/ox_core/Events/server.mdx
+++ b/pages/ox_core/Events/server.mdx
@@ -48,7 +48,7 @@ When the active group of a character has changed.
   </Tabs.Tab>
   <Tabs.Tab>
   ```ts copy
-  on('ox:setActiveGroup', (playerId: number, groupName: string, previousGroupName?: string) => {
+  on('ox:setActiveGroup', (playerId: number, groupName: string, previousGroupName: string | undefined) => {
     console.log(playersSaved);
   });
   ```
@@ -57,7 +57,7 @@ When the active group of a character has changed.
 
 * playerId: `number`
 * groupName: `string`
-* previousGroupName?: `string`
+* previousGroupName: `string | undefined`
 
 ## ox:setGroup
 

--- a/pages/ox_core/Events/server.mdx
+++ b/pages/ox_core/Events/server.mdx
@@ -41,14 +41,14 @@ When the active group of a character has changed.
 <Tabs items={['Lua', 'JS']}>
   <Tabs.Tab>
     ```lua copy
-    AddEventHandler('ox:setActiveGroup', function(playerId, groupName)
-        print(playerId, groupName)
+    AddEventHandler('ox:setActiveGroup', function(playerId, groupName, previousGroupName)
+        print(playerId, groupName, previousGroupName)
     end)
     ```
   </Tabs.Tab>
   <Tabs.Tab>
   ```ts copy
-  on('ox:setActiveGroup', (playerId: number, groupName: string) => {
+  on('ox:setActiveGroup', (playerId: number, groupName: string | false, previousGroupName: string | false) => {
     console.log(playersSaved);
   });
   ```
@@ -56,7 +56,8 @@ When the active group of a character has changed.
 </Tabs>
 
 * playerId: `number`
-* groupName: `string`
+* groupName: `string | false`
+* previousGroupName: `string | false`
 
 ## ox:setGroup
 

--- a/pages/ox_core/Events/server.mdx
+++ b/pages/ox_core/Events/server.mdx
@@ -48,7 +48,7 @@ When the active group of a character has changed.
   </Tabs.Tab>
   <Tabs.Tab>
   ```ts copy
-  on('ox:setActiveGroup', (playerId: number, groupName: string | false, previousGroupName: string | false) => {
+  on('ox:setActiveGroup', (playerId: number, groupName: string, previousGroupName?: string) => {
     console.log(playersSaved);
   });
   ```
@@ -56,8 +56,8 @@ When the active group of a character has changed.
 </Tabs>
 
 * playerId: `number`
-* groupName: `string | false`
-* previousGroupName: `string | false`
+* groupName: `string`
+* previousGroupName?: `string`
 
 ## ox:setGroup
 


### PR DESCRIPTION
Reflects changes in https://github.com/CommunityOx/ox_core/pull/32

previousGroupName should be string or undefined, in case there was no previous activeGroup