### PR TITLE
Feat: Update ox_lib's config section to include new convar

### DIFF
--- a/pages/ox_lib.mdx
+++ b/pages/ox_lib.mdx
@@ -36,6 +36,7 @@ Resource configuration is handled using [convars](https://docs.fivem.net/docs/sc
 setr ox:primaryColor blue
 setr ox:primaryShade 8
 setr ox:userLocales 1 # Allow users to select their locales using /ox_lib
+setr ox:progressPropLimit 2 # Defines the maximum number of spawned props for progressbar
 ```
 
 You'll also need to grant ace permissions to the resource.


### PR DESCRIPTION
Following the patch to ox_lib within the "fix(progress): prop replication overload" ( [a2f6b9a](https://github.com/CommunityOx/ox_lib/commit/a2f6b9a9e9e288a7de48ca5fea88c4f138496a61) ) commit