### PR TITLE
feat(guides): added guide to install & use bun

### DIFF
--- a/pages/guides.mdx
+++ b/pages/guides.mdx
@@ -5,5 +5,6 @@ General guides for working with Community Ox resources.
 - [Git](./guides/git.mdx)
 - [NodeJS](./guides/nodejs.mdx)
 - [PNPM](./guides/pnpm.mdx)
+- [BUN](./guides/bun.mdx)
 - [Ox Types](./guides/types.mdx)
 - [Visual Studio Code](./guides/vscode.mdx)

--- a/pages/guides/bun.mdx
+++ b/pages/guides/bun.mdx
@@ -1,0 +1,26 @@
+---
+title: bun
+---
+
+# bun
+
+bun is an all included toolkit for javascript and typescript development, combining nodejs and package manager into one tool.
+
+- Install [bun](https://bun.com/docs/installation).
+- Use it similarly to npm or pnpm:
+  - `bun install` - to install packages,
+  - `bun run <script_name>` - to run your scripts within the `package.json`,
+  - `bun build <entrypoint> [...flags]` - manual build command, more information in their [documenation](https://bun.com/docs/bundler)
+
+```json
+"scripts": {
+  "start": "vite",
+  "watch": "vite build --watch",
+  "build": "tsc && vite build",
+  "preview": "vite preview",
+  "format": "prettier --write \"./src/**/*.{ts,tsx,css}\""
+},
+```
+
+Using the example above `bun run build` will run the build script for the given package.<br/>
+However just running `bun build` will not work as it will trigger the internal build system.


### PR DESCRIPTION
Simple addition to the docs to include bun, as most of the repos now use it instead of `pnpm`.

Visual changes:

<img width="1144" height="612" alt="image" src="https://github.com/user-attachments/assets/9d0b43d6-3a29-4042-af21-2993e6c4bfdb" />
